### PR TITLE
Korjauksia

### DIFF
--- a/peli.py
+++ b/peli.py
@@ -175,6 +175,12 @@ class robotti:
         uusi_arvo = vanha_arvo + self.oppimisnopeus * (tuleva_arvo - vanha_arvo)
         self.arvot[edellinen_tila] = uusi_arvo
 
+    def paivita_arvot_havio(self, lauta, haviaja):
+        """ Tallentaa hävityn pelin lopputilan arvoksi 0, jotta
+        botti osaa pelata tämän siirron aina ja heti kun mahdollista.
+        """
+        self.arvot[(tuple(lauta), haviaja)] = 0
+
     def tallenna_arvot(self, tiedostonimi = "arvot.json"):
         """Tallentaa opitut arvot JSON-tiedostoon, päällekirjoitetaan kokonaan uudella tiedolla"""
         with open(tiedostonimi, "w") as tiedosto:

--- a/peli.py
+++ b/peli.py
@@ -156,7 +156,7 @@ class robotti:
         vanha_arvo = self.hae_arvot(edellinen_tila)
 
         # tarkastetaan, tuliko palkintoa ja päivitetään arvo
-        if palkinto:
+        if palkinto is not None:
             tuleva_arvo = palkinto
 
         # jos ei palkintoa, niin

--- a/treenaa.py
+++ b/treenaa.py
@@ -24,27 +24,13 @@ import time
 
 
 
-def kouluta_bottia(pelien_maara, nayta_laudat = False, n = 0):
+def kouluta_bottia(botti, pelien_maara, nayta_laudat = False, n = 0, aloittaja = 1):
     '''
     kouluttaa bottia pelaamaan itseään vastaan anettu määrä pelejä
     Mikäli haluat nähdä kun laudat vilisee, valitse näytä_laudat = True
     '''
 
-    # Luodaan botti-olio. Tämä botti pelaa sekä X:sää että O:ta.
-    botti = robotti()
-    botti.lataa_arvot() # Ladataan aiempi koulutus
-
-
-    # MUOKKAA NÄITÄ ARVOJA, ALKUUN KANNATTAA OLLA KORKEAT
-    botti.epsilon = 0.1
-    botti.oppimisnopeus = 0.1
-
-
-    pelaaja_X = 1
-    pelaaja_O = -1
-
-    print(f"Aloitetaan kouluttaminen, pelataan {pelien_maara} peliä...")
-    alkuaika = time.time()
+    print(f"Pelataan {pelien_maara} peliä jotka aloittaa pelaaja {aloittaja} ...")
     
     ''' Pääsilmukka koulutusfunktiolle'''
 
@@ -54,7 +40,7 @@ def kouluta_bottia(pelien_maara, nayta_laudat = False, n = 0):
         '''pelin alustus'''
 
         lauta = luo_lauta()
-        nykyinen_pelaaja = pelaaja_X
+        nykyinen_pelaaja = aloittaja
 
         # sanakirja johon tallennetaan viimeisin tila, jotta voimme päivittää arvoja emmekä unohda mikä tilanne oli
         edellinen_tila = {} # Avaimena toimii 1 tai -1
@@ -117,15 +103,27 @@ def kouluta_bottia(pelien_maara, nayta_laudat = False, n = 0):
         
         # Tulostetaan edistymistä
         if peli_nro % 1000 == 0:
-            print(f"pelattu {peli_nro}/{pelien_maara} peliä...")
-    
-    # kun pelit pelattu niin tallenetaan
-    botti.tallenna_arvot()
-    loppuaika = time.time()
+            print(f"pelattu {peli_nro}/{pelien_maara} peliä...", end='\r', flush=True)
+    print()
 
-    print("\n Koulutus valmis!")
-    print(f"Opitut arvot on tallennettu tiedostoon 'arvot.json'.")
-    print(f"Koulutukseen kului aikaa: {loppuaika - alkuaika:.2f} sekuntia.")
+botti = robotti()
+botti.lataa_arvot() # Ladataan aiempi koulutus
 
+# MUOKKAA NÄITÄ ARVOJA, ALKUUN KANNATTAA OLLA KORKEAT
+botti.epsilon = 0.1
+botti.oppimisnopeus = 0.1
 
-kouluta_bottia(100000)
+pelaaja_X = 1
+pelaaja_O = -1
+
+alkuaika = time.time()
+kouluta_bottia(botti, 500000, aloittaja = pelaaja_X)
+kouluta_bottia(botti, 500000, aloittaja = pelaaja_O)
+loppuaika = time.time()
+
+# kun pelit pelattu niin tallenetaan
+botti.tallenna_arvot()
+
+print("Koulutus valmis!")
+print(f"Opitut arvot on tallennettu tiedostoon 'arvot.json'.")
+print(f"Koulutukseen kului aikaa: {loppuaika - alkuaika:.2f} sekuntia.")

--- a/treenaa.py
+++ b/treenaa.py
@@ -99,6 +99,7 @@ def kouluta_bottia(pelien_maara, nayta_laudat = False, n = 0):
             voittaja = tarkista_voitto(lauta)
             haviaja = -voittaja
             if voittaja != 0:
+                botti.paivita_arvot_havio(lauta, haviaja)
                 # Annetaan palkinto voittajalle ja piiskataan häviäjää
                 botti.paivita_arvot(edellinen_tila[voittaja], None, palkinto = 1)
                 botti.paivita_arvot(edellinen_tila[haviaja], None, palkinto = 0)


### PR DESCRIPTION
### Virhe ehtolauseessa

Python-lausekkeessa numero `0` on totuusarvoltaan epätosi. Tässä `0` on yksi mahdollisista parametrina annetuista palkinnon arvoista, joten tässä pitää verrata onko sen arvo _mitä tahansa muuta kuin_ `None`. None tarkoittaa alustamatonta muuttujaa tai puuttuvaa arvoa.

### Hävityn pelin lopputilanne

Kun peli päättyy voittoon, laudan viimeinen tilanne on häviäjälle 0 pisteen arvoinen. Tieto tallennetaan, jotta botti osaa valita tämän siirron. Tällaisen siirron arvo (botille) on 1 - 0 = 1 pistettä, joten nyt se tulee valituksi muiden mahdollisuuksien joukosta. Aiemmin voittosiirrolle ei ollut pisteitä, joten valituksi tuli ensimmäinen mahdollinen (tai satunnainen) siirto.

### Koulutus

Koulutuksessa pelataan nyt myös pelit jotka pelaaja "O" aloittaa. Ilman tätä dataa kaikki siirrot näyttäytyivät botille 0.5 arvoisina (joista botti valitsi ensimmäisen). Mahdollisesti samaa dataa (ts. ilman 2-kertaista koulutusta) voisi käyttää myös kääntämällä arvot parasta siirtoa valittaessa, mutta tämä oli suoraviivaisempaa tehdä näin. Nyt lopputuloksena erilaisia pelitilanteita ja niiden arvoja tallentuu n. 2-kertainen määrä.

Huom! vanha `arvot.json` on syytä poistaa ennen treenaamista, koska vanha koulutusdata voi sisältää "vääriä" tietoja.
```
rm -f arvot.json
python treenaa.py
```